### PR TITLE
Add support for aarch64

### DIFF
--- a/src/pytailwindcss/installation.py
+++ b/src/pytailwindcss/installation.py
@@ -71,6 +71,7 @@ def format_target(os_name, arch):
         "amd64": f"{os_name}-x64{extension}",
         "x86_64": f"{os_name}-x64{extension}",
         "arm64": f"{os_name}-arm64",
+        "aarch64": f"{os_name}-arm64",
     }[arch.lower()]
 
 

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -60,6 +60,7 @@ def test_format_target():
     assert format_target("darwin", "arm64") == "macos-arm64"
     assert format_target("linux", "x86_64") == "linux-x64"
     assert format_target("linux", "amd64") == "linux-x64"
+    assert format_target("linux", "aarch64") == "linux-arm64"
 
 
 def test_format_target_uppercase_arch():
@@ -72,3 +73,4 @@ def test_format_target_uppercase_arch():
     assert format_target("darwin", "ARM64") == "macos-arm64"
     assert format_target("linux", "X86_64") == "linux-x64"
     assert format_target("linux", "AMD64") == "linux-x64"
+    assert format_target("linux", "AARCH64") == "linux-arm64"


### PR DESCRIPTION
This enables support for arch distros that report `aarch64` as their platform