### PR TITLE
Update documentation: Tailwind CSS is a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ tailwindcss -i input.css -o output.css --minify
 
 Voila!
 
+Please note that if you are using Python package manager supporting development dependencies, such as `poetry` or `pipenv`,
+`pytailwindcss` should be installed as a development dependency:
+
+```bash
+poetry add pytailwindcss --group dev
+pipenv install pytailwindcss --dev
+```
+
 ## Get started
 
 1. Install `tailwindcss` via `pip` by executing the following command:


### PR DESCRIPTION
https://tailwindcss.com/docs/installation uses `-D` switch with `npm install`, which means that it is a dev dependency. This makes sense as our styles are pre-compiled, so we don't need a compiler during run time.