### PR TITLE
Fix windows bug when using pytailwindcss.run directly

### DIFF
--- a/src/pytailwindcss/utils.py
+++ b/src/pytailwindcss/utils.py
@@ -9,7 +9,7 @@ def make_subprocess_run_kwargs(cwd=None, env=None, live_output=False):
     """
     opts = {
         "cwd": cwd or os.getcwd(),
-        "env": env or {},
+        "env": env or None,
     }
     if live_output is False:
         opts.update(


### PR DESCRIPTION
Right now, when pytailwind is ran via pytailwind.run, the **env** parameter that gets provided to subprocess.run is an empty dict. For example when I modified the pytailwind.\_\_init\_\_ file I got the following output:

```py
print([str(bin_path)] + tailwindcss_cli_args, kwargs)
output = subprocess.run([str(bin_path)] + tailwindcss_cli_args, **kwargs)
```
```
['D:\\Programming Projects\\brim\\.venv\\Lib\\site-packages\\pytailwindcss\\bin\\latest\\tailwindcss', '--input', 'D:\\Programming Projects\\brim\\brimstone\\static\\_src\\input.css', '--output', 'D:\\Programming Projects\\brim\\brimstone\\static\\dist\\css\\output.css', '--minify', '--optimize', '--cwd', 'D:\\Programming Projects\\brim\\brimstone\\templates'] {'cwd': 'D:\\Programming Projects\\brim\\brimstone', 'env': {}, 'capture_output': True, 'check': True}
```

Because **env** is an empty dict, it causes the following error on Windows, and maybe Linux and Mac but I did not test it:
```
  File "D:\Programming Projects\brim\.venv\lib\site-packages\pytailwindcss\__init__.py", line 50, in run
    output = subprocess.run([str(bin_path)] + tailwindcss_cli_args, **kwargs)
  File "AppData\Roaming\uv\python\cpython-3.9.22-windows-x86_64-none\lib\subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "C:\Users\Zwork\AppData\Roaming\uv\python\cpython-3.9.22-windows-x86_64-none\lib\subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "AppData\Roaming\uv\python\cpython-3.9.22-windows-x86_64-none\lib\subprocess.py", line 1436, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
OSError: [WinError 87] The parameter is incorrect
```

The solution is very simple, just leave env as `None`, and everything works correctly.
